### PR TITLE
Update controller.rs

### DIFF
--- a/create-rust-app/src/auth/controller.rs
+++ b/create-rust-app/src/auth/controller.rs
@@ -192,6 +192,9 @@ pub fn login(
         if device_string.len() > 256 {
             return Err((400, "'device' cannot be longer than 256 characters."));
         }
+        else {
+            device = Some(device_string.to_owned());
+        }
     }
 
     let user = User::find_by_email(&mut db, item.email.clone());


### PR DESCRIPTION
Fix for issue #72

if item.device isn't None, and its length fits within the 256 character constraint, set device to an owned copy of item.device